### PR TITLE
Problema no index

### DIFF
--- a/components/downloadEbook.js
+++ b/components/downloadEbook.js
@@ -57,7 +57,7 @@ export function downloadEbook(ebook, pages, name, start, callback) {
 
             let $ = cheerio.load(body);
             let itemLink = $("#pbk-page").attr("src");
-            let index = item.label;
+            let index = item.cfi.slice(1);
 
             console.log('\x1b[32m', '    Baixando Pagina    ' + index + '\u2713', '\x1b[0m');
 


### PR DESCRIPTION
Em alguns casos o index não era lido e o arquivo ficava sendo salvo por cima do antigo, por exemplo, a página anterior ficava como Nome_.jpeg e a posterior também como Nome_.jpeg.
Percebi que o "cfi" sempre era "/numerodapagina" então o slice resolveu.